### PR TITLE
Made issential changes

### DIFF
--- a/.github/workflows/python_profiler.yml
+++ b/.github/workflows/python_profiler.yml
@@ -14,7 +14,6 @@ jobs:
     - uses: actions/checkout@v2
     - name: Install Modules
       run: |
-        python -m pip install cProfile
         python -m pip install -r requirements.txt
         python -m pip install -r ./requirements/testing.txt
     - name: Build docker image

--- a/.github/workflows/python_profiler.yml
+++ b/.github/workflows/python_profiler.yml
@@ -12,7 +12,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+    - name: Install Modules
+      run: |
+        python -m pip install cProfile
+        python -m pip install -r requirements.txt
+        python -m pip install -r ./requirements/testing.txt
     - name: Build docker image
       run: make docker-build
     - name: Run tests
-      run: make docker-runtest-all
+      run: make test-all

--- a/manage.py
+++ b/manage.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 import os
 import sys
+import cProfile
 
 if __name__ == '__main__':
     os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'mayan.settings')
@@ -19,4 +20,4 @@ if __name__ == '__main__':
                 "forget to activate a virtual environment?"
             )
         raise
-    execute_from_command_line(sys.argv)
+    cProfile.run('execute_from_command_line(sys.argv)')


### PR DESCRIPTION
cProfile provide deterministic profiling of Python programs. A profile is a set of statistics that describes how often and for how long various parts of the program executed. cProfile will automatically output the data into stdout if not otherwise redirected. Basically, cProfile returns a chart where the columns are ncalls (# of times a function is called), tottime (the total time spent in the given function), percall (the quotient of tottime divided by ncalls), cumtime (is the cumulative time spent in this and all subfunctions), percall (is the quotient of cumtime divided by primitive calls), and filename:lineno(function) (provides the respective data of each function).

Advantages of using this dynamic testing method is it measures the efficiency of the algorithm by giving precise information of every function called, and is designed to be efficient for large applications. Additionly, cProfile provides a chart which is straightfoward for the developers.

A disadvantage of using cProfile is, for a large application, there's many functions, and since cProfile traces every function being called during testing, the information might be cumbersome.



Here's the result of cProfile when running on Mayan EDMS:
[cProfile_output.txt](https://github.com/CMU-313/fall-2021-hw5-crabs-adjust-humidity/files/7553412/cProfile_output.txt)


