### PR TITLE
Added py-spy via docker container

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,7 +1,6 @@
-version: '3.9'
+version: "3.9"
 
-x-mayan-container:
-  &mayan-container
+x-mayan-container: &mayan-container
   depends_on:
     - postgresql
     - redis
@@ -65,7 +64,7 @@ services:
     image: postgres:${MAYAN_DOCKER_POSTGRES_TAG:-10.15-alpine}
     networks:
       - bridge
-    # Disable to allow external access to the database.    
+    # Disable to allow external access to the database.
     # ports:
     #  - "5432:5432"
     restart: unless-stopped
@@ -130,15 +129,15 @@ services:
     entrypoint:
       - /bin/bash
       - -c
-      - 'mkdir --parents /mnt/index && chown mayan:mayan /mnt/index && /usr/local/bin/entrypoint.sh run_command "mountindex --allow-other creation_date /mnt/index"'  # Replace "creation_date" with the index of your choice.
+      - 'mkdir --parents /mnt/index && chown mayan:mayan /mnt/index && /usr/local/bin/entrypoint.sh run_command "mountindex --allow-other creation_date /mnt/index"' # Replace "creation_date" with the index of your choice.
     profiles:
       - mountindex
     security_opt:
       - apparmor:unconfined
     volumes:
       - type: bind
-        source: /mnt/mayan_indexes/creation_date  # Host location where the index will show up.
-        target: /mnt/index  # Location inside the container where the index will be mounted. Must the same is in the "entrypoint" section.
+        source: /mnt/mayan_indexes/creation_date # Host location where the index will show up.
+        target: /mnt/index # Location inside the container where the index will be mounted. Must the same is in the "entrypoint" section.
         bind:
           propagation: shared
 
@@ -196,6 +195,21 @@ services:
       - traefik
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
+
+  pyspy:
+    build:
+      context: pyspy/
+    pid: "host"
+    command:
+      - "record"
+      - "-o"
+      - "myprofile.svg"
+      - "--"
+      - "python"
+      - "${PWD}/../manage.py"
+    privileged: "true"
+    volumes:
+      - ${PWD}/data/pyspy:/profiles
 
   # Enable to use RabbitMQ
   # rabbitmq:

--- a/docker/pyspy/Dockerfile
+++ b/docker/pyspy/Dockerfile
@@ -1,0 +1,5 @@
+FROM python:3.6
+RUN pip install py-spy
+WORKDIR /profiles
+ENTRYPOINT [ "py-spy" ]
+CMD []


### PR DESCRIPTION
**Description**
This PR adds the profiler py-spy to the MayanEDMS application. It incorporates the profiler via a separate docker container and produces a flame graph as an svg. A flame graph is a visualization of the how much time a function spends executing. This is measured by its time on the call stack. The flame graph also has peaks which depict where in the call stack the function was called. 

**Pros:**
The slowdown that py-spy has is very optimal compared to most other python based profilers. It only slows the application down by 1.08x whereas Cprofile has a nearly 2x slowdown. It achieves this slowdown by performing a sampling of calls rather than measuring every function call on the stack. 

We get a good set of metrics given this minor slowdown and can figure out bottlenecks in our program. Over time, these images can be analyzed to observe which changes may have introduced significant lags in the program.

Lastly, py-spy runs as a separate process (hence the separate container for it) so it can run safely in production alongside the application.

**Cons:**
py-spy's primary drawback is because it runs externally from the application, it cannot profile individual functions upon request. It can be configured to sample components of an application but that is ultimately the only level of granularity that is available.
